### PR TITLE
Minor grammar fix

### DIFF
--- a/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
+++ b/files/en-us/web/api/windoworworkerglobalscope/queuemicrotask/index.html
@@ -37,7 +37,7 @@ tags:
   more about how to use microtasks and why you might choose to do so in our <a
     href="/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide">microtask guide</a>.</p>
 
-<p>The importance of microtasks comes in its ability to perform tasks asynchronously but
+<p>The importance of microtasks comes in their ability to perform tasks asynchronously but
   in a specific order. See <a
     href="/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide">Using microtasks in JavaScript
     with queueMicrotask()</a> for more details.</p>


### PR DESCRIPTION
URL: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask

Fix grammar in

> The importance of microtasks comes in its ability to perform tasks asynchronously but in a specific order.

"its" should be "their" since "ability" refers to the ability of "microtasks"—not "the importance".